### PR TITLE
Fix null SortChain with PHP version check

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,6 @@ $yourCustomCollection->usort($sortChain);
 
 ## Known issues
 
-- Sorting with an empty chain will return different values in PHP 5 vs PHP 7.
 - Need to investigate supporting native sort flags
 
 ## License

--- a/src/SortChain.php
+++ b/src/SortChain.php
@@ -6,9 +6,15 @@ class SortChain
 {
     private $callables = [];
 
+    private static $nullOperatorEquality;
+
     public function __construct(array $callables)
     {
         $this->callables = $callables;
+
+        if (static::$nullOperatorEquality === null) {
+            static::$nullOperatorEquality = version_compare(PHP_VERSION, '7.0.0', '>=') ? 0 : 1;
+        }
     }
 
     public function compare(callable $callable)
@@ -42,6 +48,10 @@ class SortChain
 
     public function __invoke($a, $b)
     {
+        if (empty($this->callables)) {
+            return static::$nullOperatorEquality;
+        }
+
         foreach ($this->callables as $callable) {
             $result = $callable($a, $b);
 

--- a/src/SortChain.php
+++ b/src/SortChain.php
@@ -13,7 +13,7 @@ class SortChain
         $this->callables = $callables;
 
         if (static::$nullOperatorEquality === null) {
-            static::$nullOperatorEquality = version_compare(PHP_VERSION, '7.0.0', '>=') ? 0 : 1;
+            static::$nullOperatorEquality = version_compare(PHP_VERSION, '7.0.0', '>=') || defined('HHVM_VERSION')? 0 : 1;
         }
     }
 

--- a/tests/SortChainTest.php
+++ b/tests/SortChainTest.php
@@ -107,4 +107,12 @@ class SortChainTest extends \PHPUnit_Framework_TestCase
             Sort::chain()->values($unsorted)
         );
     }
+
+    public function testMainlyHomogeneousSetWithEmptyChain()
+    {
+        $this->assertEquals(
+            [1, 2, 1, 1, 1],
+            Sort::chain()->values([1, 2, 1, 1, 1])
+        );
+    }
 }


### PR DESCRIPTION
The original idea for the SortChain was that when no callables were attached, it would create a comparison function that did not re-arrange any items in the original array. This would be useful so you could create a basic object and then later decorate it, perhaps in response to user input.

However, creating a non-reordering usort comparison function appears to be version dependent: https://3v4l.org/JPqJd 

Always returning 0 leaves the elements in the original order, but only in PHP 7 and HHVM. PHP 5.x  will return them in reversed order. While I can understand both behaviors, it would be ideal to bridge this gap since it's an inconsistency in the API and a few folks on twitter have reported being bitten by similar issues.

Therefore, the following solutions are:
- Throw an error when SortChain has no callables available.
- Change the SortChain API to never allow creating an empty instance (possibly using __callStatic to create and proxy instance methods?)
- Use a PHP version check to return the desired result in PHP 5.

This PR uses the third option. It adds a potentially unnecessary if(empty($this->callables)) clause to separate the case of a null object from the case of an "all matching" example; I'm not 100% sure this is necessary but until I can flesh out a test example, it seems prudent.

If anyone has any thoughts or counter suggestions, please let me know. Thanks!
